### PR TITLE
超级用户初始化匹配前端规则

### DIFF
--- a/src/main/java/com/github/system/auth/init/SystemInit.java
+++ b/src/main/java/com/github/system/auth/init/SystemInit.java
@@ -64,11 +64,11 @@ public class SystemInit implements CommandLineRunner {
     public void onceSystemUserInit() {
         if (userService.count() == 0) {
             // 生成密码
-            String password = RandomUtil.randomString(6);
+            String password = RandomUtil.randomString(8);
             logger.info("创建初始超级用户：admin 密码：" + password);
             SysUser sysUser = new SysUser();
             sysUser.setUsername("admin");
-            sysUser.setPassword(userService.encodePassword(password));
+            sysUser.setPassword(userService.encodePassword(SecureUtil.md5(password)));
             userService.save(sysUser);
             // 写入超管权限
             sysRoleService.addUserRole(sysUser.getId(), "ADMIN");


### PR DESCRIPTION
Vue前端默认校验规则长度最少为8位，更改密码初始化长度
用户初始化密码经一次Md5后加盐加密入库，防止初始超级用户密码无法登录问题